### PR TITLE
Revert "Disable shell commands for all roles in provisioning templates (#4385)"

### DIFF
--- a/nvflare/fuel/hci/server/authz.py
+++ b/nvflare/fuel/hci/server/authz.py
@@ -74,7 +74,7 @@ class AuthzFilter(CommandFilter):
         submitter = Person(
             name=conn.get_prop(ConnProps.SUBMITTER_NAME, ""),
             org=conn.get_prop(ConnProps.SUBMITTER_ORG, ""),
-            role=conn.get_prop(ConnProps.SUBMITTER_ROLE, ""),
+            role=conn.get_prop(ConnProps.SUBMITTER_ORG, ""),
         )
 
         ctx = AuthzContext(user=user, submitter=submitter, right=cmd_entry.name)

--- a/nvflare/fuel/sec/authz.py
+++ b/nvflare/fuel/sec/authz.py
@@ -44,12 +44,13 @@ class Person(object):
         self.role = _normalize_str(role, FieldNames.USER_ROLE)
 
     def __str__(self):
-        if (not self.name) and (not self.org) and (not self.role):
-            return "None"
         name = self.name if self.name else "None"
         org = self.org if self.org else "None"
         role = self.role if self.role else "None"
-        return f"{name}:{org}:{role}"
+        if (not name) and (not org) and (not role):
+            return "None"
+        else:
+            return f"{name}:{org}:{role}"
 
 
 class AuthzContext(object):
@@ -226,9 +227,9 @@ class Policy(object):
         return self.roles
 
     def _eval_for_role(self, role: str, site_org: str, ctx: AuthzContext):
-        conds = self.role_right_map.get(_role_right_key(role, ctx.right))
+        conds = self.role_right_map.get(_role_right_key(role, _ANY_RIGHT))
         if not conds:
-            conds = self.role_right_map.get(_role_right_key(role, _ANY_RIGHT))
+            conds = self.role_right_map.get(_role_right_key(role, ctx.right))
 
         if not conds:
             return False

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -318,16 +318,7 @@ default_authz: |
   {
     "format_version": "1.0",
     "permissions": {
-      "project_admin": {
-        "submit_job": "any",
-        "clone_job": "any",
-        "manage_job": "any",
-        "download_job": "any",
-        "view": "any",
-        "operate": "any",
-        "shell_commands": "none",
-        "byoc": "any"
-      },
+      "project_admin": "any",
       "org_admin": {
         "submit_job": "none",
         "clone_job": "none",
@@ -335,7 +326,7 @@ default_authz: |
         "download_job": "o:submitter",
         "view": "any",
         "operate": "o:site",
-        "shell_commands": "none",
+        "shell_commands": "o:site",
         "byoc": "none"
       },
       "lead": {
@@ -345,7 +336,7 @@ default_authz: |
         "download_job": "n:submitter",
         "view": "any",
         "operate": "o:site",
-        "shell_commands": "none",
+        "shell_commands": "o:site",
         "byoc": "any"
       },
       "member": {
@@ -358,16 +349,7 @@ cc_authz: |
   {
     "format_version": "1.0",
     "permissions": {
-      "project_admin": {
-        "submit_job": "any",
-        "clone_job": "any",
-        "manage_job": "any",
-        "download_job": "any",
-        "view": "any",
-        "operate": "any",
-        "shell_commands": "none",
-        "byoc": "any"
-      },
+      "project_admin": "any",
       "org_admin": {
         "submit_job": "none",
         "clone_job": "none",


### PR DESCRIPTION
This reverts #4385.\n\nReason: rollback the shell-command authorization changes introduced by that PR.