### PR TITLE
Add ad-hoc connection documentation limitations

### DIFF
--- a/docs/programming_guide/execution_api_type/3rd_party_integration.rst
+++ b/docs/programming_guide/execution_api_type/3rd_party_integration.rst
@@ -368,6 +368,8 @@ configure the comm_config.json on the client site as follows:
 
 This file must be placed into the site's "local" folder within its workspace.
 
+For ad-hoc direct connection limitations and behavior, see :ref:`communication_configuration`.
+
 Pay attention to the following:
 
 - For most cases, the "scheme" should be set to "tcp" to get the best performance.

--- a/docs/user_guide/admin_guide/configurations/communication_configuration.rst
+++ b/docs/user_guide/admin_guide/configurations/communication_configuration.rst
@@ -156,6 +156,12 @@ Secondly, in the "adhoc" section, you can further specify what scheme to use for
 In this example, we use tcp for ad-hoc connections, and we will listen on port number 8008 or 9008.
 Note that the ad-hoc connection's port number is dynamically determined based on the port information in the config.
 
+Ad-hoc connections have the following limitations:
+
+- They do not work well in environments with firewalls that only allow pre-defined ports. The listener may use a dynamically assigned port, so the connection can be blocked by firewall rules.
+- They are only a communication optimization. They are best-effort only, and the direct connection may not be created if the network environment does not allow it.
+- They are created on demand only after CellNet sees the first message from the target cell. Because establishing the ad-hoc connection takes time, there can be an initial delay before messages start going through the direct path.
+
 Config Properties
 -----------------
 


### PR DESCRIPTION
## Summary
- document ad-hoc connection limitations in the communication configuration guide
- point the 3rd-party integration guide to the central communication configuration section instead of repeating the same details

## Testing
- not run (docs-only changes)