### PR TITLE
[2.8] Gate job-shipped FOBS decomposers behind BYOC (FLARE-2977)

### DIFF
--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -22,7 +22,7 @@ import sys
 import warnings
 from typing import List, Optional, Union
 
-from nvflare.apis.app_validation import AppValidator
+from nvflare.apis.app_validation import AppValidationKey, AppValidator
 from nvflare.apis.client import Client
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLContext
@@ -341,16 +341,26 @@ def fobs_initialize(workspace: Workspace = None, job_id: Optional[str] = None):
 
 def custom_fobs_initialize(workspace: Workspace = None, job_id: Optional[str] = None):
     if workspace:
+        # site-level decomposers are installed by the site admin and always loaded
         site_custom_dir = workspace.get_client_custom_dir()
         decomposer_dir = os.path.join(site_custom_dir, ConfigVarName.DECOMPOSER_MODULE)
         if os.path.exists(decomposer_dir):
             register_custom_folder(decomposer_dir)
 
         if job_id:
+            # decomposers shipped with the job are custom code: only load them for BYOC-enabled jobs
             app_custom_dir = workspace.get_app_config_dir(job_id)
             decomposer_dir = os.path.join(app_custom_dir, ConfigVarName.DECOMPOSER_MODULE)
-            if os.path.exists(decomposer_dir):
+            if os.path.exists(decomposer_dir) and _job_allows_byoc(workspace, job_id):
                 register_custom_folder(decomposer_dir)
+
+
+def _job_allows_byoc(workspace: Workspace, job_id: str) -> bool:
+    try:
+        job_meta = get_job_meta_from_workspace(workspace, job_id)
+    except Exception:
+        return False
+    return bool(job_meta.get(AppValidationKey.BYOC, False))
 
 
 def nvflare_fobs_initialize():

--- a/tests/unit_test/private/fed/utils/fed_utils_test.py
+++ b/tests/unit_test/private/fed/utils/fed_utils_test.py
@@ -17,11 +17,17 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nvflare.apis.app_validation import AppValidationKey
+from nvflare.apis.fl_constant import ConfigVarName
 from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.fobs import Decomposer
 from nvflare.fuel.utils.fobs.datum import DatumManager
 from nvflare.fuel.utils.fobs.fobs import register_custom_folder
-from nvflare.private.fed.utils.fed_utils import create_job_processing_context_properties, extract_participants
+from nvflare.private.fed.utils.fed_utils import (
+    create_job_processing_context_properties,
+    custom_fobs_initialize,
+    extract_participants,
+)
 
 
 class ExampleTestClass:
@@ -83,3 +89,59 @@ class TestFedUtils:
         with patch("nvflare.private.fed.utils.fed_utils.get_job_meta_from_workspace", return_value=[]):
             with pytest.raises(RuntimeError, match="job_meta must be dict"):
                 create_job_processing_context_properties(workspace, "job-1")
+
+    @staticmethod
+    def _make_workspace():
+        workspace = MagicMock()
+        workspace.get_client_custom_dir.return_value = os.path.join("site", "custom")
+        workspace.get_app_config_dir.return_value = os.path.join("job", "config")
+        return workspace
+
+    @patch("nvflare.private.fed.utils.fed_utils.register_custom_folder")
+    @patch("nvflare.private.fed.utils.fed_utils.get_job_meta_from_workspace")
+    @patch("os.path.exists", return_value=True)
+    def test_job_decomposers_ignored_when_not_byoc(self, mock_exists, mock_get_meta, mock_register):
+        # job meta without the BYOC flag => job is not allowed to bring custom code
+        mock_get_meta.return_value = {}
+        workspace = self._make_workspace()
+
+        custom_fobs_initialize(workspace, job_id="job-1")
+
+        registered_dirs = [call.args[0] for call in mock_register.call_args_list]
+        job_decomposer_dir = os.path.join("job", "config", ConfigVarName.DECOMPOSER_MODULE)
+        site_decomposer_dir = os.path.join("site", "custom", ConfigVarName.DECOMPOSER_MODULE)
+
+        # the job's config/nvflare_decomposers must be ignored for a non-BYOC job
+        assert job_decomposer_dir not in registered_dirs
+        # site decomposers are installed by the admin and must still be loaded
+        assert site_decomposer_dir in registered_dirs
+
+    @patch("nvflare.private.fed.utils.fed_utils.register_custom_folder")
+    @patch("nvflare.private.fed.utils.fed_utils.get_job_meta_from_workspace")
+    @patch("os.path.exists", return_value=True)
+    def test_job_decomposers_loaded_when_byoc(self, mock_exists, mock_get_meta, mock_register):
+        mock_get_meta.return_value = {AppValidationKey.BYOC: True}
+        workspace = self._make_workspace()
+
+        custom_fobs_initialize(workspace, job_id="job-1")
+
+        registered_dirs = [call.args[0] for call in mock_register.call_args_list]
+        job_decomposer_dir = os.path.join("job", "config", ConfigVarName.DECOMPOSER_MODULE)
+
+        # a BYOC job is allowed to ship its own decomposers
+        assert job_decomposer_dir in registered_dirs
+
+    @patch("nvflare.private.fed.utils.fed_utils.register_custom_folder")
+    @patch("nvflare.private.fed.utils.fed_utils.get_job_meta_from_workspace")
+    @patch("os.path.exists", return_value=True)
+    def test_job_decomposers_ignored_when_meta_unavailable(self, mock_exists, mock_get_meta, mock_register):
+        # if the job meta cannot be read, default to not loading the job decomposers
+        mock_get_meta.side_effect = FileNotFoundError("missing job meta")
+        workspace = self._make_workspace()
+
+        custom_fobs_initialize(workspace, job_id="job-1")
+
+        registered_dirs = [call.args[0] for call in mock_register.call_args_list]
+        job_decomposer_dir = os.path.join("job", "config", ConfigVarName.DECOMPOSER_MODULE)
+
+        assert job_decomposer_dir not in registered_dirs


### PR DESCRIPTION
## Summary
Fixes **FLARE-2977** (P0): non-BYOC jobs could execute config-shipped FOBS decomposer Python.

A job app could ship Python at `app_*/config/nvflare_decomposers/*.py`. During `fobs_initialize → custom_fobs_initialize`, that folder was passed to `register_custom_folder()`, which appends it to `sys.path` and `import`s every `.py` (running import-time code and registering any `Decomposer`). Because BYOC detection only looks for a `custom/` folder, such jobs were never flagged BYOC, so the `class_allow_list` / component authorizer never guarded this code path — an RCE bypass for jobs whose BYOC permission is denied.

## Change
In `custom_fobs_initialize()` (`nvflare/private/fed/utils/fed_utils.py`):
- **Site-level** decomposers (`get_client_custom_dir()/nvflare_decomposers`, admin-controlled) → still loaded unconditionally.
- **Job-level** decomposers (`get_app_config_dir(job_id)/nvflare_decomposers`) → now loaded **only when the job meta is BYOC-enabled** (`AppValidationKey.BYOC`). New helper `_job_allows_byoc()` reads the job meta and **fails safe** (returns `False`) if it can't be read.

### Why this blocks the PoC
The PoC job has no `custom/` folder, so its meta is `byoc=False`. The gate therefore skips its `config/nvflare_decomposers` → the malicious module is never imported (no `sys.path` pollution either), and the FedAvg `recompose()` trigger is defeated because the unregistered type is rejected by the FOBS type whitelist.

This implements the ticket's **recommended fix #2** (gate job config decomposer loading on BYOC) and **#3** (non-BYOC jobs use only built-in/site-predeployed decomposers).

## Tests
Added to `tests/unit_test/private/fed/utils/fed_utils_test.py`:
- `test_job_decomposers_ignored_when_not_byoc` — job `config/nvflare_decomposers` ignored when `byoc` is false; site decomposers still load.
- `test_job_decomposers_loaded_when_byoc` — loaded when `byoc=True` (positive control).
- `test_job_decomposers_ignored_when_meta_unavailable` — fail-safe when meta can't be read.

All 7 tests in the file pass.

## Not included (follow-ups from the ticket)
- **#1** Validator-level BYOC detection (mark/reject jobs that ship `config/nvflare_decomposers`) — would reject such jobs at submission rather than silently not loading them.
- **#5** Constrain `FedAvg.save_filename` (path traversal) — explicitly independent of this path.

## Behavior-change note
Legitimate jobs that currently ship decomposers in `config/nvflare_decomposers` **without** a `custom/` folder will stop loading them (intended hardening). Such users should move the code under `custom/` (proper BYOC job) or have the site pre-deploy the decomposers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)